### PR TITLE
Specify DPI for display

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ More details can be found [here](https://github.com/suchja/x11server/blob/master
 
 Running a container based on this image is quite easy. It is intended to be run as daemon. So you can run via:
 
-`docker run -d --name display -e VNC_PASSWORD=newPW -e XFB_SCREEN=1280x800x24 -p 5900:5900 suchja/x11server`
+`docker run -d --name display -e VNC_PASSWORD=newPW -e XFB_SCREEN=1280x800x24 -e XFB_SCREEN_DPI=150 -p 5900:5900 suchja/x11server`
 
 You should give it a name (here `display`), because a container running the client should be linked with this container. Forwarding the port `5900` allows you to access the VNC server from within your network.
 
@@ -30,6 +30,10 @@ This variable is mandatory and specifies the password you need to enter into you
 
 Specifies screen width, height, and depth (WxHxD). By default, screen has the dimensions 1024x768x24.
 
+`XFB_SCREEN_DPI`
+
+Specifies DPI for the display (Dots Per Inch). If not specified, uses the default DPI (100).
+
 ### docker-compose
 You can use `docker-compose` to avoid typing or copy-and-pasting all the stuff again and again on the command line. Here an excerpt from a `docker-compose.yml` file starting a container from this image:
 
@@ -41,6 +45,7 @@ xserver:
 	environment:
 		VNC_PASSWORD: yourPW
 		XFB_SCREEN: 1280x800x24
+                XFB_SCREEN_DPI: 150
 ```
 
 Save this inside `docker-compose.yml`, add a proper password and call `docker-compose up`. Now you will have a running X11 server waiting for X11 clients and VNC clients to connect.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,10 @@ if [ -z "$XFB_SCREEN" ]; then
 	XFB_SCREEN=1024x768x24
 fi
 
+if [ ! -z "$XFB_SCREEN_DPI" ]; then
+	DPI_OPTIONS="-dpi $XFB_SCREEN_DPI"
+fi
+
 # first we need our security cookie and add it to user's .Xauthority
 mcookie | sed -e 's/^/add :0 MIT-MAGIC-COOKIE-1 /' | xauth -q
 
@@ -18,7 +22,7 @@ mcookie | sed -e 's/^/add :0 MIT-MAGIC-COOKIE-1 /' | xauth -q
 xauth nlist :0 | sed -e 's/^..../ffff/' | xauth -f /Xauthority/xserver.xauth nmerge -
 
 # now boot X-Server, tell it to our cookie and give it sometime to start up
-Xvfb :0 -auth ~/.Xauthority -screen 0 $XFB_SCREEN >>~/xvfb.log 2>&1 &
+Xvfb :0 -auth ~/.Xauthority $DPI_OPTIONS -screen 0 $XFB_SCREEN >>~/xvfb.log 2>&1 &
 sleep 2
 
 # finally we can run the VNC-Server based on our just started X-Server


### PR DESCRIPTION
Hello,

I just added an environment variable (`XFB_SCREEN_DPI`) in `docker-entrypoint.sh`, in order to specify DPI for the display. Indeed, the default configuration (100 DPI) render fonts too small on Hi DPI displays.